### PR TITLE
Ignore toccata build product. Convenience scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dependencies
 *.dSYM
 build
+toccata

--- a/bin/build-toccata.sh
+++ b/bin/build-toccata.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+TOCCATA_DIR="$(cd -P -- $(dirname -- $0)/../ && pwd)"
+
+clang -g \
+  -v \
+  -fno-objc-arc \
+  -o toccata \
+  -I$TOCCATA_DIR \
+  -std=c99 \
+  -DCHECK_MEM_LEAK=1 \
+  $TOCCATA_DIR/core.c \
+  toccata.c \
+  -lpthread

--- a/bin/toccata.sh
+++ b/bin/toccata.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+TOCCATA_DIR="$(cd -P -- $(dirname -- $0)/../ && pwd)"
+
+PATH=$PATH:$TOCCATA_DIR
+
+usage() {
+    echo "Usage: ./bin/toccata.sh input.toc > output.c"
+    exit 1
+}
+
+if [ -z "$1" ]; then
+    usage
+fi
+
+toccata $1


### PR DESCRIPTION
Ignore toccata build product. Convenience scripts for building toccota and running the resulting binary und er bin