### PR TITLE
Leverage Clojure syntax highlighting for Toccata files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.toc linguist-language=Clojure


### PR DESCRIPTION
Functionality of [linguist](https://github.com/github/linguist) described [here](https://github.com/github/linguist#using-gitattributes). 

<img width="856" alt="Screen Shot 2019-11-21 at 8 30 03 PM" src="https://user-images.githubusercontent.com/2127465/69390579-b720cb80-0c9d-11ea-8573-9c37a6a8c2cb.png">
